### PR TITLE
SYSTEMS-33　Cherry様のホームページの特徴エリア（画像フル）にスタイルを適応する

### DIFF
--- a/components/FeatureImageFull.vue
+++ b/components/FeatureImageFull.vue
@@ -1,17 +1,16 @@
 <template>
-  <section class="Feature1">
+  <section>
     <h3
       v-if="data.titleCopy"
-      class="Feature1_Title text-center"
+      class="text-center"
       v-html="data.titleCopy"
     ></h3>
-    <p v-if="data.text" class="Feature1_Text text-center" v-html="data.text"></p>
+    <p v-if="data.text" class="text-center" v-html="data.text"></p>
     <img
       v-if="data.image && data.image.src"
       :src="data.image.src"
-      height="307"
       alt=""
-      class="Feature1_Image d-block mx-auto object-fit-cover w-75"
+      class="d-block object-fit-cover px-lg-5 px-3 w-100"
     />
   </section>
 </template>

--- a/components/FeatureImageFull.vue
+++ b/components/FeatureImageFull.vue
@@ -1,16 +1,17 @@
 <template>
-  <section>
+  <section class="my-5">
     <h3
       v-if="data.titleCopy"
       class="text-center"
       v-html="data.titleCopy"
     ></h3>
-    <p v-if="data.text" class="text-center" v-html="data.text"></p>
+    <p v-if="data.text" class="text-center mb-4" v-html="data.text"></p>
     <img
       v-if="data.image && data.image.src"
       :src="data.image.src"
       alt=""
       class="d-block object-fit-cover px-lg-5 px-3 w-100"
+      style="height: 25vw;"
     />
   </section>
 </template>

--- a/components/FeatureImageFull.vue
+++ b/components/FeatureImageFull.vue
@@ -2,10 +2,10 @@
   <section class="Feature1">
     <h3
       v-if="data.titleCopy"
-      class="Feature1_Title"
+      class="Feature1_Title text-center"
       v-html="data.titleCopy"
     ></h3>
-    <p v-if="data.text" class="Feature1_Text" v-html="data.text"></p>
+    <p v-if="data.text" class="Feature1_Text text-center" v-html="data.text"></p>
     <img
       v-if="data.image && data.image.src"
       :src="data.image.src"

--- a/components/FeatureImageFull.vue
+++ b/components/FeatureImageFull.vue
@@ -9,10 +9,9 @@
     <img
       v-if="data.image && data.image.src"
       :src="data.image.src"
-      width="980"
       height="307"
       alt=""
-      class="Feature1_Image"
+      class="Feature1_Image d-block mx-auto object-fit-cover w-75"
     />
   </section>
 </template>

--- a/components/Hero.vue
+++ b/components/Hero.vue
@@ -1,7 +1,7 @@
 <template>
   <section class="container mb-5">
     <div class="row">
-      <div class="col-6 d-flex align-items-center">
+      <div class="col-6 d-flex align-items-center p-4">
         <div>
           <p
           v-if="data.shoulderCopy"


### PR DESCRIPTION
# 概要
Feature/image full area styling
こちらの対応です↓
https://acecore.backlog.com/view/SYSTEMS-33
# 対応内容
すべてbootstrapを使用して整えました。
# その他
imgのheightを画面サイズに合わせて伸縮させようとすると、画像がトリミングされずにheightが修正イメージより大きくなる。imgのheightを修正イメージに合わせてheighe=”307”やｗ-25にすると伸縮されなくなる。今は後者にしてあります。どちらの方が良いと思われますか？
