### PR TITLE
SYSTEMS-34Cherry様ホームぺージの特徴エリア（画像右）にスタイルを適応する

### DIFF
--- a/components/FeatureImageFull.vue
+++ b/components/FeatureImageFull.vue
@@ -1,16 +1,15 @@
 <template>
-  <section class="my-5">
+  <section class="my-5 mx-lg-5 mx-3">
     <h3
       v-if="data.titleCopy"
-      class="text-center"
-      v-html="data.titleCopy"
-    ></h3>
-    <p v-if="data.text" class="text-center mb-4" v-html="data.text"></p>
+      class="text-center mx-3"
+    >{{data.titleCopy}}</h3>
+    <p v-if="data.text" class="text-center mb-4 mx-3">{{data.text}}</p>
     <img
       v-if="data.image && data.image.src"
       :src="data.image.src"
       alt=""
-      class="d-block object-fit-cover px-lg-5 px-3 w-100"
+      class="d-block object-fit-cover w-100 p-3"
       style="height: 25vw;"
     />
   </section>

--- a/components/FeatureImageFull.vue
+++ b/components/FeatureImageFull.vue
@@ -2,7 +2,8 @@
   <section class="my-5 mx-lg-5 mx-3">
     <h3 v-if="data.titleCopy" class="text-center mx-3">{{ data.titleCopy }}</h3>
     <p v-if="data.text" class="text-center mb-4 mx-3">{{ data.text }}</p>
-    <img v-if="data.image && data.image.src" :src="data.image.src" alt="" class="d-block object-fit-cover w-100 p-3"
+    <img v-if="data.image && data.image.src" :src="data.image.src" alt="" 
+      class="d-block object-fit-cover w-100 p-3"
       style="height: 25vw;" />
   </section>
 </template>

--- a/components/FeatureImageFull.vue
+++ b/components/FeatureImageFull.vue
@@ -1,17 +1,9 @@
 <template>
   <section class="my-5 mx-lg-5 mx-3">
-    <h3
-      v-if="data.titleCopy"
-      class="text-center mx-3"
-    >{{data.titleCopy}}</h3>
-    <p v-if="data.text" class="text-center mb-4 mx-3">{{data.text}}</p>
-    <img
-      v-if="data.image && data.image.src"
-      :src="data.image.src"
-      alt=""
-      class="d-block object-fit-cover w-100 p-3"
-      style="height: 25vw;"
-    />
+    <h3 v-if="data.titleCopy" class="text-center mx-3">{{ data.titleCopy }}</h3>
+    <p v-if="data.text" class="text-center mb-4 mx-3">{{ data.text }}</p>
+    <img v-if="data.image && data.image.src" :src="data.image.src" alt="" class="d-block object-fit-cover w-100 p-3"
+      style="height: 25vw;" />
   </section>
 </template>
 

--- a/components/FeatureImageFull.vue
+++ b/components/FeatureImageFull.vue
@@ -2,9 +2,13 @@
   <section class="my-5 mx-lg-5 mx-3">
     <h3 v-if="data.titleCopy" class="text-center mx-3">{{ data.titleCopy }}</h3>
     <p v-if="data.text" class="text-center mb-4 mx-3">{{ data.text }}</p>
-    <img v-if="data.image && data.image.src" :src="data.image.src" alt="" 
-      class="d-block object-fit-cover w-100 p-3"
-      style="height: 25vw;" />
+      <img 
+        v-if="data.image && data.image.src" 
+        :src="data.image.src" 
+        alt="" 
+        class="d-block object-fit-cover w-100 p-3"
+        style="height: 25vw;" 
+      />
   </section>
 </template>
 

--- a/components/FeatureImageRight.vue
+++ b/components/FeatureImageRight.vue
@@ -1,17 +1,18 @@
 <template>
-  <section class="Feature2">
-    <div class="Feature2_Inner">
-      <div class="Feature2_Data">
+  <section class="my-5">
+    <div class="row">
+    <div class="d-flex bd-highlight">
+      <div class="col-6 bd-highlight">
         <h3
           v-if="data.titleCopy"
-          class="Feature2_Title"
           v-html="data.titleCopy"
         ></h3>
-        <p v-if="data.text" class="Feature2_Text" v-html="data.text"></p>
+        <p v-if="data.text" v-html="data.text"></p>
+      </div>   
+      <div v-if="data.image && data.image.src" class="col-6 bd-highlight">
+        <img :src="data.image.src" alt="" class="img-fluid w-100"/>
       </div>
-      <div v-if="data.image && data.image.src" class="Feature2_Image">
-        <img :src="data.image.src" width="407" height="248" alt="" />
-      </div>
+    </div>
     </div>
   </section>
 </template>

--- a/components/FeatureImageRight.vue
+++ b/components/FeatureImageRight.vue
@@ -1,18 +1,11 @@
 <template>
-  <section class="my-5">
-    <div class="row">
-    <div class="d-flex bd-highlight">
-      <div class="col-6 bd-highlight">
-        <h3
-          v-if="data.titleCopy"
-          v-html="data.titleCopy"
-        ></h3>
-        <p v-if="data.text" v-html="data.text"></p>
-      </div>   
-      <div v-if="data.image && data.image.src" class="col-6 bd-highlight">
-        <img :src="data.image.src" alt="" class="img-fluid w-100"/>
-      </div>
+  <section class="row mx-lg-5 mx-3 my-5">
+    <div class="col-6">
+      <h3 v-if="data.titleCopy">{{ data.titleCopy }}</h3>
+      <p v-if="data.text">{{ data.text }}</p>
     </div>
+    <div v-if="data.image && data.image.src" class="col-6">
+      <img :src="data.image.src" alt="" class="img-fluid w-100" />
     </div>
   </section>
 </template>

--- a/components/FeatureImageRight.vue
+++ b/components/FeatureImageRight.vue
@@ -4,7 +4,7 @@
       <h3 v-if="data.titleCopy">{{ data.titleCopy }}</h3>
       <p v-if="data.text">{{ data.text }}</p>
     </div>
-    <div v-if="data.image && data.image.src" class="col-6">
+    <div v-if="data.image && data.image.src" class="col-lg-6">
       <img :src="data.image.src" alt="" class="img-fluid w-100" />
     </div>
   </section>

--- a/components/Hero.vue
+++ b/components/Hero.vue
@@ -12,7 +12,11 @@
         </div>
       </div>
       <div v-if="data.backgroundImage" class="col-lg-6 p-0">
-        <img :src="data.backgroundImage.src" class="img-fluid rounded-4 w-100 h-auto" alt="" />
+        <img 
+          :src="data.backgroundImage.src" 
+          class="img-fluid rounded-4 w-100 h-auto" 
+          alt="" 
+        />
       </div>
   </section>
 </template>

--- a/components/Hero.vue
+++ b/components/Hero.vue
@@ -1,30 +1,17 @@
 <template>
-  <section class="container mb-5">
-    <div class="row">
+  <section class="container my-5 ">
+    <div class="row mx-lg-5 mx-3">
       <div class="col-6 d-flex align-items-center p-4">
         <div>
-          <p
-          v-if="data.shoulderCopy"
-          class="text-muted"
-          v-html="data.shoulderCopy"
-        ></p>
-        <h2
-          v-if="data.titleCopy"
-          v-html="data.titleCopy"
-        ></h2>
-        <p v-if="data.text" v-html="data.text"></p>
-        <a
-          v-if="data.ctaButton && data.ctaButton.label"
-          class="btn btn-outline-primary"
-          :href="data.ctaButton.url"
-          rel="noreferrer noopener"
-          :target="data.ctaButton.newTab ? '_blank' : ''"
-          >{{ data.ctaButton.label }}</a
-        >
+          <p v-if="data.shoulderCopy" class="text-muted">{{ data.shoulderCopy }}</p>
+          <h2 v-if="data.titleCopy">{{ data.titleCopy }}</h2>
+          <p v-if="data.text">{{ data.text }}</p>
+          <a v-if="data.ctaButton && data.ctaButton.label" class="btn btn-outline-primary" :href="data.ctaButton.url"
+            rel="noreferrer noopener" :target="data.ctaButton.newTab ? '_blank' : ''">{{ data.ctaButton.label }}</a>
         </div>
       </div>
-      <div v-if="data.backgroundImage" class="col-lg-6">
-        <img :src="data.backgroundImage.src" class="img-fluid rounded-4 w-100 h-auto my-lg-3 mb-3" alt="" />
+      <div v-if="data.backgroundImage" class="col-lg-6 p-0">
+        <img :src="data.backgroundImage.src" class="img-fluid rounded-4 w-100 h-auto" alt="" />
       </div>
     </div>
   </section>

--- a/components/Hero.vue
+++ b/components/Hero.vue
@@ -1,19 +1,19 @@
 <template>
-  <section class="container my-5 ">
-    <div class="row mx-lg-5 mx-3">
+  <section class="container my-5 row mx-lg-5 mx-3">
       <div class="col-6 d-flex align-items-center p-4">
         <div>
           <p v-if="data.shoulderCopy" class="text-muted">{{ data.shoulderCopy }}</p>
           <h2 v-if="data.titleCopy">{{ data.titleCopy }}</h2>
           <p v-if="data.text">{{ data.text }}</p>
-          <a v-if="data.ctaButton && data.ctaButton.label" class="btn btn-outline-primary" :href="data.ctaButton.url"
-            rel="noreferrer noopener" :target="data.ctaButton.newTab ? '_blank' : ''">{{ data.ctaButton.label }}</a>
+          <a v-if="data.ctaButton && data.ctaButton.label" 
+            class="btn btn-outline-primary" :href="data.ctaButton.url"
+            rel="noreferrer noopener" :target="data.ctaButton.newTab ? 
+            '_blank' : ''">{{ data.ctaButton.label }}</a>
         </div>
       </div>
       <div v-if="data.backgroundImage" class="col-lg-6 p-0">
         <img :src="data.backgroundImage.src" class="img-fluid rounded-4 w-100 h-auto" alt="" />
       </div>
-    </div>
   </section>
 </template>
 


### PR DESCRIPTION
# 概要
ブランチ名→Feature/systems-34_ image_right_area_styling
下記の対応です↓
https://acecore.backlog.com/view/SYSTEMS-34
# 対応内容
　・左右の余白を整えた
　・画面サイズに合わせて伸縮可能にした
　・フォーマットした
　・少しの修正なのでHero.vueとFeaturelmageFull.vueも同じブランチでコミットした(フォーマットなど)
# その他
このエリアを合わせて三つに、非常にわずかですが左右のmarginの差ができてしまいました。どう思われますか